### PR TITLE
Fix script generator typings

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -32,6 +32,11 @@ declare module '@google-cloud/firestore' {
     data(): any;
   }
 }
+declare namespace FirebaseFirestore {
+  interface DocumentSnapshot {
+    data(): any;
+  }
+}
 declare module '@google-cloud/storage' {
   export class Storage {
     constructor(options?: any);


### PR DESCRIPTION
## Summary
- cleanup imports in scriptGenerator
- use Firestore namespace typings
- narrow axios/cheerio types
- update Firestore update call
- add minimal `FirebaseFirestore.DocumentSnapshot` declaration

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68542b3e2684832daf9fda9601657f4e