### PR TITLE
Add VideosFeed screen

### DIFF
--- a/app/screens/VideosFeed.tsx
+++ b/app/screens/VideosFeed.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react'
+import { SafeAreaView, FlatList, View, Text, ActivityIndicator, StyleSheet } from 'react-native'
+import { Video } from 'expo-av'
+import { initializeApp } from 'firebase/app'
+import { getFirestore, collection, query, orderBy, onSnapshot, DocumentData, limit } from 'firebase/firestore'
+
+// TODO: replace with your Firebase web config or use env variables
+const firebaseConfig = { /* your config */ }
+const app = initializeApp(firebaseConfig)
+const db = getFirestore(app)
+
+export default function VideosFeed() {
+  const [videos, setVideos] = useState<DocumentData[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const q = query(
+      collection(db, 'videos'),
+      orderBy('fetchedAt', 'desc'),
+      limit(10)
+    )
+    const unsubscribe = onSnapshot(q, (snapshot: any) => {
+      setVideos(snapshot.docs.map((doc: any) => doc.data()))
+      setLoading(false)
+    })
+    return unsubscribe
+  }, [])
+
+  if (loading) return <ActivityIndicator style={styles.loader} />
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList
+        data={videos}
+        keyExtractor={(item: any) => item.fetchedAt.toMillis().toString()}
+        renderItem={({ item }: { item: any }) => (
+          <View style={styles.card}>
+            <Video
+              source={{ uri: item.videoUrl }}
+              style={styles.video}
+              useNativeControls
+              resizeMode="contain"
+            />
+            <Text style={styles.headline}>{item.headline}</Text>
+          </View>
+        )}
+      />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0D0D0D' },
+  loader: { flex: 1, justifyContent: 'center' },
+  card: { margin: 16, borderRadius: 12, overflow: 'hidden' },
+  video: { width: '100%', height: 200 },
+  headline: { color: '#FFF', marginTop: 8, fontSize: 16, fontWeight: 'bold' }
+})

--- a/global.d.ts
+++ b/global.d.ts
@@ -5,10 +5,17 @@ declare namespace JSX {
   }
 }
 
-declare module 'react';
+declare module 'react' {
+  export function useState<T>(initial: T): [T, (v: T) => void];
+  export function useEffect(effect: any, deps?: any[]): void;
+  const React: any;
+  export default React;
+}
 declare module 'react-native' {
   export const Text: any;
   export const View: any;
+  export const FlatList: any;
+  export const ActivityIndicator: any;
   export const SafeAreaView: any;
   export const useColorScheme: any;
   export const StyleSheet: any;
@@ -78,3 +85,16 @@ declare module 'express' {
 
 declare var process: any;
 declare var Buffer: any;
+declare module 'expo-av' {
+  export const Video: any;
+}
+declare module 'firebase/app'
+declare module 'firebase/firestore' {
+  export interface DocumentData { [key: string]: any }
+  export const getFirestore: any;
+  export const collection: any;
+  export const query: any;
+  export const orderBy: any;
+  export const onSnapshot: any;
+  export const limit: any;
+}


### PR DESCRIPTION
## Summary
- create `VideosFeed` screen to display video feed
- expand custom typings for React, React Native, expo-av and Firebase

## Testing
- `npx tsc -p tsconfig.json`
- `npm install firebase expo-av` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68542f63a184832dad9eb85796699710